### PR TITLE
fix: nomes espaçados de pastas e adição de dados.txt

### DIFF
--- a/Cadastro.c
+++ b/Cadastro.c
@@ -3,42 +3,63 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <ctype.h>
 
-
-// struct paciente
 typedef struct {
     char nome[50];
-    char inscricao[21];
+    char inscricao[11];
+    char procedimento[100];
     int idade;
 } Paciente;
 
-//diretiva para mudança de função a depender do sistema operacional
+//funcao decidida a partir de sistema operacional especifico
 #ifdef _WIN32
     #define criarDiretorio _mkdir
 #else
     #define criarDiretorio mkdir
-
 #endif
+
+// funcao para substituir espaços por underlines
+void removerespacosNomePasta(char *nome) {
+    for (int i = 0; nome[i]; i++) {
+        if (isspace(nome[i])) {
+            nome[i] = '_';
+        }
+    }
+}
 
 void cadastrarPacientes(Paciente *pacientes, int quantidade) {
     criarDiretorio("./pacientes", 0777);
 
     for (int i = 0; i < quantidade; i++) {
-
         printf("\nCadastro do Paciente %d:\n", i+1);
+        
         printf("Nome: ");
-        scanf("%49s", pacientes[i].nome);
+        fgets(pacientes[i].nome, sizeof(pacientes[i].nome), stdin);
+        pacientes[i].nome[strcspn(pacientes[i].nome, "\n")] = '\0'; 
+        
         printf("Número de Inscrição (10 digitos): ");
-        scanf("%10s", pacientes[i].inscricao);
+        fgets(pacientes[i].inscricao, sizeof(pacientes[i].inscricao), stdin);
+        pacientes[i].inscricao[strcspn(pacientes[i].inscricao, "\n")] = '\0';
+
+        printf("Procedimento a ser realizado: ");
+        fgets(pacientes[i].procedimento, sizeof(pacientes[i].procedimento), stdin);
+        pacientes[i].procedimento[strcspn(pacientes[i].procedimento, "\n")] = '\0';
+        
         printf("Idade: ");
         scanf("%d", &pacientes[i].idade);
+        while (getchar() != '\n'); 
+
+        char nomeAlterado[50];
+        strcpy(nomeAlterado, pacientes[i].nome);
+        removerespacosNomePasta(nomeAlterado);
 
         char nomePasta[200];
-        snprintf(nomePasta, sizeof(nomePasta), "./pacientes/%s", (pacientes[i].nome));
+        snprintf(nomePasta, sizeof(nomePasta), "./pacientes/%s", nomeAlterado);
         criarDiretorio(nomePasta, 0777);
 
         char nomeArquivo[300];
-        snprintf(nomeArquivo, sizeof(nomeArquivo), "%s/%s.txt", nomePasta, pacientes[i].nome);
+        snprintf(nomeArquivo, sizeof(nomeArquivo), "%s/dados.txt", nomePasta);
 
         FILE *arquivo = fopen(nomeArquivo, "w");
         if (arquivo == NULL) {
@@ -46,10 +67,11 @@ void cadastrarPacientes(Paciente *pacientes, int quantidade) {
             continue;
         }
         
-        fprintf(arquivo, "nome: %s, inscricao: %s, idade: %d", 
-                pacientes[i].nome, 
+        fprintf(arquivo, "nome: %s, inscricao: %s, idade: %d, procedimento: %s", 
+                pacientes[i].nome,  
                 pacientes[i].inscricao, 
-                pacientes[i].idade);
+                pacientes[i].idade,
+                pacientes[i].procedimento);
 
         fclose(arquivo);
         printf("Arquivo criado com sucesso em %s!\n", nomeArquivo);
@@ -57,10 +79,11 @@ void cadastrarPacientes(Paciente *pacientes, int quantidade) {
 }
 
 int main() {
-    int quantidade, continuar = 0;
+    int quantidade;
 
     printf("Quantos pacientes deseja cadastrar? ");
     scanf("%d", &quantidade);
+    while (getchar() != '\n'); // limpeza do buffer
 
     Paciente *pacientes = (Paciente *)malloc(quantidade * sizeof(Paciente));
     if (pacientes == NULL) {
@@ -68,11 +91,8 @@ int main() {
         return 1;
     }
 
-
-
     cadastrarPacientes(pacientes, quantidade);
 
     free(pacientes);
-
     return 0;
 }


### PR DESCRIPTION
ajeitei alguns erros prévios adicionando uma função para "ajeitar" o nome dos pacientes para as pastas, adicionando "_" onde haviam " ". também fiz com que fosse gerado um arquivo chamado "dados.txt" ao inves do nome do paciente, visto que ficaria redundante.